### PR TITLE
fix: Change from symlink to copy method for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,15 @@ curl -fsSL https://raw.githubusercontent.com/kumagaias/kiro-best-practices/main/
 
 ## Update
 
+To update to the latest version, run the install script again:
+
 ```bash
-cd ~/.kiro/kiro-best-practices && git pull
+curl -fsSL https://raw.githubusercontent.com/kumagaias/kiro-best-practices/main/install.sh | bash
 ```
+
+This will:
+1. Update the repository in `~/.kiro/kiro-best-practices`
+2. Copy updated files to `~/.kiro/` (you'll be prompted for conflicts)
 
 ## Uninstall
 
@@ -61,15 +67,15 @@ Note: This will NOT remove project-specific `.kiro/` directories.
 │       ├── settings/
 │       ├── steering/
 │       ├── scripts/
-│       ├── templates/       # Templates (not symlinked)
-│       └── docs/            # Documentation (not symlinked)
-├── hooks/          -> kiro-best-practices/.kiro/hooks/*.json
-├── settings/       -> kiro-best-practices/.kiro/settings/*.json
-├── steering/       -> kiro-best-practices/.kiro/steering/*.md
-└── scripts/        -> kiro-best-practices/.kiro/scripts/*.sh
+│       ├── templates/       # Templates (not copied)
+│       └── docs/            # Documentation (not copied)
+├── hooks/          # Copied from kiro-best-practices/.kiro/hooks/*.json
+├── settings/       # Copied from kiro-best-practices/.kiro/settings/*.json
+├── steering/       # Copied from kiro-best-practices/.kiro/steering/*.md
+└── scripts/        # Copied from kiro-best-practices/.kiro/scripts/*.sh
 ```
 
-**Note**: Only files that Kiro reads are symlinked. Templates and docs are accessed directly from the repository.
+**Note**: Files are copied (not symlinked) to ensure compatibility across all projects. Templates and docs remain in the repository.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ if [ ${#CONFLICTS[@]} -gt 0 ]; then
   else
     # Interactive mode: ask user
     echo "Options:"
-    echo "  1) Overwrite all (replace with symlinks)"
+    echo "  1) Overwrite all (replace with new copies)"
     echo "  2) Skip all (keep existing files)"
     echo "  3) Ask for each file"
     echo ""
@@ -194,25 +194,25 @@ should_skip() {
   return 1
 }
 
-# Create symlinks for individual files
-echo "  🔗 Creating symlinks..."
+# Copy files
+echo "  📄 Copying files..."
 
 # Hooks
-should_skip "hooks/pre-commit-security.json" || ln -sf "$REPO_DIR/.kiro/hooks/pre-commit-security.json" "$KIRO_HOME/hooks/pre-commit-security.json"
-should_skip "hooks/run-all-tests.json" || ln -sf "$REPO_DIR/.kiro/hooks/run-all-tests.json" "$KIRO_HOME/hooks/run-all-tests.json"
-should_skip "hooks/run-tests.json" || ln -sf "$REPO_DIR/.kiro/hooks/run-tests.json" "$KIRO_HOME/hooks/run-tests.json"
-should_skip "hooks/commit-push-pr.json" || ln -sf "$REPO_DIR/.kiro/hooks/commit-push-pr.json" "$KIRO_HOME/hooks/commit-push-pr.json"
-should_skip "hooks/documentation-update-reminder.json" || ln -sf "$REPO_DIR/.kiro/hooks/documentation-update-reminder.json" "$KIRO_HOME/hooks/documentation-update-reminder.json"
-should_skip "hooks/setup-on-session-start.json" || ln -sf "$REPO_DIR/.kiro/hooks/setup-on-session-start.json" "$KIRO_HOME/hooks/setup-on-session-start.json"
+should_skip "hooks/pre-commit-security.json" || cp "$REPO_DIR/.kiro/hooks/pre-commit-security.json" "$KIRO_HOME/hooks/pre-commit-security.json"
+should_skip "hooks/run-all-tests.json" || cp "$REPO_DIR/.kiro/hooks/run-all-tests.json" "$KIRO_HOME/hooks/run-all-tests.json"
+should_skip "hooks/run-tests.json" || cp "$REPO_DIR/.kiro/hooks/run-tests.json" "$KIRO_HOME/hooks/run-tests.json"
+should_skip "hooks/commit-push-pr.json" || cp "$REPO_DIR/.kiro/hooks/commit-push-pr.json" "$KIRO_HOME/hooks/commit-push-pr.json"
+should_skip "hooks/documentation-update-reminder.json" || cp "$REPO_DIR/.kiro/hooks/documentation-update-reminder.json" "$KIRO_HOME/hooks/documentation-update-reminder.json"
+should_skip "hooks/setup-on-session-start.json" || cp "$REPO_DIR/.kiro/hooks/setup-on-session-start.json" "$KIRO_HOME/hooks/setup-on-session-start.json"
 
 # Settings
-should_skip "settings/mcp.json" || ln -sf "$REPO_DIR/.kiro/settings/mcp.json" "$KIRO_HOME/settings/mcp.json"
-should_skip "settings/mcp.local.json.example" || ln -sf "$REPO_DIR/.kiro/settings/mcp.local.json.example" "$KIRO_HOME/settings/mcp.local.json.example"
+should_skip "settings/mcp.json" || cp "$REPO_DIR/.kiro/settings/mcp.json" "$KIRO_HOME/settings/mcp.json"
+should_skip "settings/mcp.local.json.example" || cp "$REPO_DIR/.kiro/settings/mcp.local.json.example" "$KIRO_HOME/settings/mcp.local.json.example"
 
 # Steering
-should_skip "steering/project.md" || ln -sf "$REPO_DIR/.kiro/steering/project.md" "$KIRO_HOME/steering/project.md"
-should_skip "steering/tech.md" || ln -sf "$REPO_DIR/.kiro/steering/tech.md" "$KIRO_HOME/steering/tech.md"
-should_skip "steering/deployment-workflow.md" || ln -sf "$REPO_DIR/.kiro/steering/deployment-workflow.md" "$KIRO_HOME/steering/deployment-workflow.md"
+should_skip "steering/project.md" || cp "$REPO_DIR/.kiro/steering/project.md" "$KIRO_HOME/steering/project.md"
+should_skip "steering/tech.md" || cp "$REPO_DIR/.kiro/steering/tech.md" "$KIRO_HOME/steering/tech.md"
+should_skip "steering/deployment-workflow.md" || cp "$REPO_DIR/.kiro/steering/deployment-workflow.md" "$KIRO_HOME/steering/deployment-workflow.md"
 
 # Language configuration - copy template and customize
 if ! should_skip "steering/language.md"; then
@@ -234,7 +234,7 @@ if ! should_skip "steering/language.md"; then
 fi
 
 # Scripts
-should_skip "scripts/security-check.sh" || ln -sf "$REPO_DIR/.kiro/scripts/security-check.sh" "$KIRO_HOME/scripts/security-check.sh"
+should_skip "scripts/security-check.sh" || cp "$REPO_DIR/.kiro/scripts/security-check.sh" "$KIRO_HOME/scripts/security-check.sh"
 
 # Set execute permissions on scripts
 chmod +x "$KIRO_HOME/scripts"/*.sh 2>/dev/null || true

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -54,7 +54,7 @@ fi
 echo ""
 echo "🗑️  Removing files..."
 
-# Remove symlinks first (before removing repository)
+# Remove copied files
 rm -f "$KIRO_HOME/hooks/pre-commit-security.json" 2>/dev/null && echo "  ✓ Removed hooks/pre-commit-security.json" || true
 rm -f "$KIRO_HOME/hooks/run-all-tests.json" 2>/dev/null && echo "  ✓ Removed hooks/run-all-tests.json" || true
 rm -f "$KIRO_HOME/hooks/run-tests.json" 2>/dev/null && echo "  ✓ Removed hooks/run-tests.json" || true


### PR DESCRIPTION
Closes #1

## Changes
- Changed `install.sh` to copy files instead of creating symbolic links
- Updated `uninstall.sh` to remove copied files
- Updated `README.md` documentation to reflect the copy method and update process

## Reason
Symbolic links don't work properly in some project environments. Copying files ensures they can be read correctly in all projects.

## Testing
- Verified script syntax
- Confirmed file operations use `cp` instead of `ln -sf`