### PR TITLE
docs: Add AWS best practices and tool version management

### DIFF
--- a/.kiro/hooks/sync-spec-translations.kiro.hook
+++ b/.kiro/hooks/sync-spec-translations.kiro.hook
@@ -1,0 +1,18 @@
+{
+  "name": "Sync Spec Translations",
+  "version": "1.0.0",
+  "description": "Automatically sync spec document translations when spec files are edited",
+  "when": {
+    "type": "fileEdited",
+    "patterns": [
+      ".kiro/specs/**/requirements.md",
+      ".kiro/specs/**/design.md",
+      ".kiro/specs/**/tasks.md",
+      ".kiro/specs/**/bugfix.md"
+    ]
+  },
+  "then": {
+    "type": "runCommand",
+    "command": "~/.kiro/hooks/common/scripts/sync-spec-translations.sh"
+  }
+}

--- a/.kiro/steering/deployment-workflow.md
+++ b/.kiro/steering/deployment-workflow.md
@@ -29,6 +29,17 @@ General project standards applicable to various projects.
 
 All development work must start with a GitHub Issue.
 
+**IMPORTANT**: For new projects, create `.tool-versions` first:
+
+```bash
+# Initialize tool versions (run once per project)
+mise use terraform@latest nodejs@lts python@latest
+# Or: asdf local terraform latest && asdf local nodejs lts && asdf local python latest
+
+# Install tools
+mise install  # or: asdf install
+```
+
 ```bash
 # 1. Create GitHub Issue
 gh issue create --title "Add user authentication" --body "Description..."

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -28,6 +28,38 @@ General best practices applicable to various programming languages and projects.
 
 ---
 
+## Tool Version Management
+
+**IMPORTANT**: Always create `.tool-versions` at project start to lock tool versions.
+
+Use mise or asdf to manage tool versions consistently across projects.
+
+### Initial Setup (per project)
+
+```bash
+# Create .tool-versions with latest stable versions
+mise use terraform@latest nodejs@lts python@latest
+
+# Or with asdf
+asdf local terraform latest
+asdf local nodejs lts
+asdf local python latest
+
+# Install tools
+mise install  # or: asdf install
+```
+
+### Version Selection Guidelines
+
+- **terraform**: Use `@latest` for latest stable version
+- **nodejs**: Use `@lts` for Long Term Support version (recommended for production)
+- **python**: Use `@latest` for latest stable version
+
+**Note**: 
+- Tool versions are captured at project start and committed to `.tool-versions`
+- Use `@lts` for Node.js to ensure stability (not `@latest`)
+- The `.tool-versions` file locks versions for consistent environments across team
+
 ## Essential Commands
 
 ```bash


### PR DESCRIPTION
Closes #3

## Changes
- Added spec translation sync hook for non-English chat languages
- Added tool version management section to tech.md (mise/asdf)
- Added .tool-versions initialization instructions to deployment-workflow.md
- Documented @lts usage for Node.js to ensure LTS versions

## Details
- Spec documents are automatically translated when chat language is not English
- Tool versions are captured at project start using mise/asdf
- Node.js uses @lts to get Long Term Support versions (not @latest)