### PR TITLE
refactor: Symlink mcp.json instead of copying, remove ENABLE_BEDROCK option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,11 @@ curl -fsSL https://raw.githubusercontent.com/kumagaias/kiro-best-practices/main/
 
 **Configuration Options:**
 - `KIRO_CHAT_LANG`: Agent chat language (default: English)
-- `ENABLE_BEDROCK`: Enable Bedrock Advisor (default: false, requires AWS account)
 
 To use Japanese for agent chat:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kumagaias/kiro-best-practices/main/install.sh | KIRO_CHAT_LANG=Japanese bash
-```
-
-To enable Bedrock Advisor (requires AWS account):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/kumagaias/kiro-best-practices/main/install.sh | ENABLE_BEDROCK=true bash
-```
-
-Combine options:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/kumagaias/kiro-best-practices/main/install.sh | KIRO_CHAT_LANG=Japanese ENABLE_BEDROCK=true bash
 ```
 
 **Note**: Project language is fixed to English for all projects (README, Issues, PRs, commits).
@@ -48,7 +35,17 @@ To update to the latest version:
 cd ~/.kiro/kiro-best-practices && git pull
 ```
 
-Files are symlinked, so updates automatically reflect in `~/.kiro/`. Only `mcp.json` and `language.md` need reinstallation if you want to change settings.
+All files are symlinked, so updates automatically reflect in `~/.kiro/`. Only `language.md` needs reinstallation if you want to change the chat language.
+
+## Bedrock Advisor
+
+Bedrock Advisor is disabled by default. To enable it (requires AWS account), edit:
+
+```bash
+# Edit the repository file directly
+vim ~/.kiro/kiro-best-practices/.kiro/settings/mcp.json
+# Set "disabled": false for the bedrock-advisor entry
+```
 
 ## Customization
 
@@ -62,7 +59,7 @@ Files are symlinked, so updates automatically reflect in `~/.kiro/`. Only `mcp.j
 **Best Practices:**
 - Keep common standards in global configuration
 - Customize project-specific settings in `.kiro/` within each project
-- Don't modify `~/.kiro/` directly - it will be overwritten on update
+- Don't modify `~/.kiro/` directly - symlinks point to the repository
 
 ### What to Customize Where
 
@@ -104,15 +101,17 @@ Note: This will NOT remove project-specific `.kiro/` directories.
 │       ├── settings/
 │       ├── steering/
 │       ├── scripts/
+│       ├── agents/
 │       ├── templates/       # Templates (not symlinked)
 │       └── docs/            # Documentation (not symlinked)
-├── hooks/          # Symlinked to kiro-best-practices/.kiro/hooks/*.json
-├── settings/       # mcp.json copied (customized), others symlinked
-├── steering/       # language.md copied (customized), others symlinked
-└── scripts/        # Symlinked to kiro-best-practices/.kiro/scripts/*.sh
+├── hooks/          # Symlinked
+├── settings/       # Symlinked (including mcp.json)
+├── steering/       # language.md copied, others symlinked
+├── scripts/        # Symlinked
+└── agents/         # Symlinked
 ```
 
-**Note**: Files are symlinked for automatic updates via `git pull`. Only `mcp.json` and `language.md` are copied for customization.
+**Note**: All files are symlinked for automatic updates via `git pull`. Only `language.md` is copied for customization.
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ KIRO_HOME="$HOME/.kiro"
 REPO_DIR="$KIRO_HOME/kiro-best-practices"
 
 # Check if environment variables are set (non-interactive mode)
-if [ -n "$ENABLE_BEDROCK" ] || [ -n "$KIRO_CHAT_LANG" ]; then
+if [ -n "$KIRO_CHAT_LANG" ]; then
   INTERACTIVE=false
 elif [ -t 0 ]; then
   INTERACTIVE=true
@@ -23,26 +23,6 @@ fi
 
 echo "🚀 Kiro Best Practices Installer"
 echo "================================="
-echo ""
-
-# Bedrock Advisor option
-if [ "$INTERACTIVE" = true ]; then
-  echo "🤖 Enable Bedrock Advisor (requires AWS account)?"
-  echo "  AI advisor for debugging and problem-solving"
-  echo ""
-  read -p "Enable? (y/N): " -n 1 -r
-  echo ""
-  
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    ENABLE_BEDROCK="true"
-  else
-    ENABLE_BEDROCK="false"
-  fi
-else
-  ENABLE_BEDROCK="${ENABLE_BEDROCK:-false}"
-fi
-
-echo "✓ Bedrock Advisor: $ENABLE_BEDROCK"
 echo ""
 
 # Language selection
@@ -168,28 +148,11 @@ while IFS= read -r -d '' file; do
   create_symlink "$file" "$KIRO_HOME/$rel_path"
 done < <(find "$REPO_DIR/.kiro/hooks" -maxdepth 1 -name "*.json" -print0 2>/dev/null || true)
 
-# Symlink settings (JSON files) - except mcp.json which needs customization
+# Symlink settings (all JSON files)
 echo "  🔗 Linking settings..."
 while IFS= read -r -d '' file; do
   rel_path="${file#$REPO_DIR/.kiro/}"
-  basename=$(basename "$file")
-  
-  if [ "$basename" = "mcp.json" ]; then
-    # Copy mcp.json and customize
-    cp "$file" "$KIRO_HOME/$rel_path"
-    
-    # Enable Bedrock Advisor if requested
-    if [ "$ENABLE_BEDROCK" = "true" ]; then
-      if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' '/"bedrock-advisor": {/,/"disabled": true/ s/"disabled": true/"disabled": false/' "$KIRO_HOME/$rel_path"
-      else
-        sed -i '/"bedrock-advisor": {/,/"disabled": true/ s/"disabled": true/"disabled": false/' "$KIRO_HOME/$rel_path"
-      fi
-    fi
-    echo "  ✓ Copied and customized mcp.json"
-  else
-    create_symlink "$file" "$KIRO_HOME/$rel_path"
-  fi
+  create_symlink "$file" "$KIRO_HOME/$rel_path"
 done < <(find "$REPO_DIR/.kiro/settings" -maxdepth 1 -name "*.json" -print0 2>/dev/null || true)
 
 # Symlink steering (MD files, excluding language template)
@@ -239,16 +202,15 @@ echo "✅ Installation complete!"
 echo ""
 echo "📋 Installed to ~/.kiro/ (via symlinks):"
 echo "  ✓ hooks/          - Agent hooks (symlinked)"
-echo "  ✓ settings/       - MCP configuration (mcp.json copied, others symlinked)"
+echo "  ✓ settings/       - MCP configuration (symlinked)"
 echo "  ✓ steering/       - Development guidelines (symlinked)"
 echo "  ✓ scripts/        - Utility scripts (symlinked)"
 echo "  ✓ agents/         - Agent configurations (symlinked)"
 echo ""
 echo "🌐 Agent chat language: $CHAT_LANG"
-echo "🤖 Bedrock Advisor: $ENABLE_BEDROCK"
 echo ""
-echo "💡 Files are symlinked - updates to repository will auto-reflect"
+echo "💡 All files are symlinked - git pull auto-reflects updates"
 echo ""
 echo "📚 Update: cd ~/.kiro/kiro-best-practices && git pull"
-echo "🔄 Reinstall: curl ... | bash (to update language/bedrock settings)"
+echo "🔄 Reinstall: curl ... | bash (to update language settings)"
 echo ""


### PR DESCRIPTION
Closes #10\n\n## Changes\n\n- `mcp.json` をコピーからシンボリンクに変更 → `git pull` で自動更新されるように\n- `ENABLE_BEDROCK` オプションと関連する interactive プロンプトを削除\n- Bedrock を有効にしたい場合は `~/.kiro/kiro-best-practices/.kiro/settings/mcp.json` を直接編集する運用に変更\n- README を更新